### PR TITLE
Add requirements.txt with matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+matplotlib


### PR DESCRIPTION
I forked the repo and cloned it, tried running the absenteeism_rate_calculator.py with `python absenteeism_rate_calculator.py` but it gave me an error that `matplotlib` is not yet installed. I run the `pip install -r requirements.txt` as said in the README, but there's no requirements.txt yet, and that gave me another error. 